### PR TITLE
Add new systemd-compatible sd-encryptssh hook.

### DIFF
--- a/initcpio/install/sd-encryptssh
+++ b/initcpio/install/sd-encryptssh
@@ -1,0 +1,29 @@
+#!/bin/bash
+make_etc_passwd() {
+    sed -i '/^root/ s|/bin/bash|/bin/cryptsetup_shell|' "${BUILDROOT}"/etc/passwd
+    echo '/bin/cryptsetup_shell' >> "${BUILDROOT}"/etc/shells
+}
+
+build() {
+    add_binary "/usr/share/mkinitcpio-utils/utils/shells/cryptsetup_shell_systemd" "/bin/cryptsetup_shell"
+    add_binary "/lib/systemd/systemd-reply-password"
+    add_binary "/usr/bin/stty"
+
+    make_etc_passwd
+}
+
+help() {
+    cat <<HELPEOF
+This hook is works *together with* the sd-encrypt hook and allows for an
+encrypted root device to be unlocked remotely over SSH. It works with both
+mkinitcpio-dropbear and mkinitcpio-tinyssh hooks. It DOES NOT perform any
+network interface configuration, and requires the sd-encrypt hook to do the
+actual cryptsetup step.
+
+Use this hook in combination with any early userspace networking hook, such as
+mkinitcpio-netconf or mkinitcpio-ppp. Place this hook AFTER any network
+configuration hook and BEFORE the sd-ecnrypt and filesystems hook.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/utils/shells/cryptsetup_shell_systemd
+++ b/utils/shells/cryptsetup_shell_systemd
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+get_ini_key()
+{
+    key="$1"
+    file="$2"
+    sed -n "/^${key}=/ s/^${key}=// p" "$file"
+}
+
+die()
+{
+    echo "$@" >&2
+    exit 1
+}
+
+for askfile in /run/systemd/ask-password/ask.*; do
+    [ -f "$askfile" ] || continue
+    msg=$(get_ini_key Message "$askfile")
+    socket=$(get_ini_key Socket "$askfile")
+    pid=$(get_ini_key PID "$askfile")
+
+    [ -n "$msg" -a -n "$socket" -a -n "$pid" ] || continue
+    kill -0 $pid || continue
+
+    stty -echo
+    read -p "$msg " passwd
+    echo "$passwd" | /lib/systemd/systemd-reply-password 1 "$socket"
+    exit 0
+
+done
+
+
+echo "Not ready to receive passphrase yet"
+exit 1


### PR DESCRIPTION
This adds another hook that allows the SSH encryption password
functionality to work with the sd-encrypt hook (and a systemd init).
Unlike the encryptssh hook, the sd-encryptssh hook is an addition to the
sd-encrypt hook and relies on the systemd password agent feature to pass
the entered password on to systemd, which does the actual unlocking.

Signed-off-by: Toke Høiland-Jørgensen toke@toke.dk
