### PR TITLE
fill the gap with encrypt provided by cryptsetup

### DIFF
--- a/initcpio/hooks/encryptssh
+++ b/initcpio/hooks/encryptssh
@@ -3,172 +3,178 @@
 run_hook ()
 {
     /sbin/modprobe -a -q dm-crypt >/dev/null 2>&1
-    if [ -e "/sys/class/misc/device-mapper" ]; then
-        if [ ! -e "/dev/mapper/control" ]; then
-            mkdir /dev/mapper
-            mknod "/dev/mapper/control" c $(cat /sys/class/misc/device-mapper/dev | sed 's|:| |')
-        fi
-        [ "${quiet}" = "y" ] && CSQUIET=">/dev/null"
+    [ "${quiet}" = "y" ] && CSQUIET=">/dev/null"
 
-        # Get keyfile if specified
-        ckeyfile="/crypto_keyfile.bin"
-        if [ "x${cryptkey}" != "x" ]; then
-            ckdev="$(echo "${cryptkey}" | cut -d: -f1)"
-            ckarg1="$(echo "${cryptkey}" | cut -d: -f2)"
-            ckarg2="$(echo "${cryptkey}" | cut -d: -f3)"
-            if poll_device "${ckdev}" ${rootdelay}; then
-                case ${ckarg1} in
-                    *[!0-9]*)
-                        # Use a file on the device
-                        # ckarg1 is not numeric: ckarg1=filesystem, ckarg2=path
-                        mkdir /ckey
-                        mount -r -t ${ckarg1} ${ckdev} /ckey
-                        dd if=/ckey/${ckarg2} of=${ckeyfile} >/dev/null 2>&1
-                        umount /ckey
-                        ;;
-                    *)
-                        # Read raw data from the block device
-                        # ckarg1 is numeric: ckarg1=offset, ckarg2=length
-                        dd if=${ckdev} of=${ckeyfile} bs=1 skip=${ckarg1} count=${ckarg2} >/dev/null 2>&1
-                        ;;
-                esac
-            fi
-            [ ! -f ${ckeyfile} ] && echo "Keyfile could not be opened. Reverting to passphrase."
-        fi
-
-        if [ -n "${cryptdevice}" ]; then
-            DEPRECATED_CRYPT=0
-            cryptdev="$(echo "${cryptdevice}" | cut -d: -f1)"
-            cryptname="$(echo "${cryptdevice}" | cut -d: -f2)"
-            cryptoptions="$(echo "${cryptdevice}" | cut -d: -f3)"
-        else
-            DEPRECATED_CRYPT=1
-            cryptdev="${root}"
-            cryptname="root"
-        fi
-
-        warn_deprecated() {
-            echo "The syntax 'root=${root}' where '${root}' is an encrypted volume is deprecated"
-            echo "Use 'cryptdevice=${root}:root root=/dev/mapper/root' instead."
-        }
-
-        OLDIFS="${IFS}"
-        IFS=","
-        for cryptopt in ${cryptoptions}; do
-            case ${cryptopt} in
-                allow-discards)
-                    echo "Enabling TRIM/discard support."
-                    cryptargs="${cryptargs} --allow-discards"
+    # Get keyfile if specified
+    ckeyfile="/crypto_keyfile.bin"
+    if [ -n "$cryptkey" ]; then
+        IFS=: read ckdev ckarg1 ckarg2 <<EOF
+$cryptkey
+EOF
+        if [ "$ckdev" = "rootfs" ]; then
+            ckeyfile=$ckarg1
+        elif resolved=$(resolve_device "${ckdev}" ${rootdelay}); then
+            case ${ckarg1} in
+                *[!0-9]*)
+                    # Use a file on the device
+                    # ckarg1 is not numeric: ckarg1=filesystem, ckarg2=path
+                    mkdir /ckey
+                    mount -r -t "$ckarg1" "$resolved" /ckey
+                    dd if="/ckey/$ckarg2" of="$ckeyfile" >/dev/null 2>&1
+                    umount /ckey
                     ;;
                 *)
-                    echo "Encryption option '${cryptopt}' not known, ignoring." >&2
+                    # Read raw data from the block device
+                    # ckarg1 is numeric: ckarg1=offset, ckarg2=length
+                    dd if="$resolved" of="$ckeyfile" bs=1 skip="$ckarg1" count="$ckarg2" >/dev/null 2>&1
                     ;;
             esac
-        done
-        IFS="${OLDIFS}"
+        fi
+        [ ! -f ${ckeyfile} ] && echo "Keyfile could not be opened. Reverting to passphrase."
+    fi
 
-        echo ${cryptname} > /.cryptname
-        echo ${cryptargs} > /.cryptargs
+    # This may happen if third party hooks do the crypt setup
+    if [ -b "/dev/mapper/${cryptname}" ]; then
+        echo "Device ${cryptname} already exists, not doing any crypt setup."
+        return 0
+    fi
 
-        if resolved=$(resolve_device "${cryptdev}" ${rootdelay}); then
+    if [ -n "${cryptdevice}" ]; then
+        DEPRECATED_CRYPT=0
+        IFS=: read cryptdev cryptname cryptoptions <<EOF
+$cryptdevice
+EOF
+    else
+        DEPRECATED_CRYPT=1
+        cryptdev="${root}"
+        cryptname="root"
+    fi
 
-            echo ${resolved} > /.cryptdev
+    warn_deprecated() {
+        echo "The syntax 'root=${root}' where '${root}' is an encrypted volume is deprecated"
+        echo "Use 'cryptdevice=${root}:root root=/dev/mapper/root' instead."
+    }
 
-            if /sbin/cryptsetup isLuks ${resolved} >/dev/null 2>&1; then
-                [ ${DEPRECATED_CRYPT} -eq 1 ] && warn_deprecated
-                dopassphrase=1
-                # If keyfile exists, try to use that
-                if [ -f ${ckeyfile} ]; then
-                    if eval /sbin/cryptsetup --key-file ${ckeyfile} luksOpen ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; then
-                        dopassphrase=0
-                    else
-                        echo "Invalid keyfile. Reverting to passphrase."
-                    fi
+    set -f
+    OLDIFS="$IFS"; IFS=,
+    for cryptopt in ${cryptoptions}; do
+        case ${cryptopt} in
+            allow-discards|discard)
+                cryptargs="${cryptargs} --allow-discards"
+                ;;
+            no-read-workqueue|perf-no_read_workqueue)
+                cryptargs="${cryptargs} --perf-no_read_workqueue"
+                ;;
+            no-write-workqueue|perf-no_write_workqueue)
+                cryptargs="${cryptargs} --perf-no_write_workqueue"
+                ;;
+            *)
+                echo "Encryption option '${cryptopt}' not known, ignoring." >&2
+                ;;
+        esac
+    done
+    set +f
+    IFS="$OLDIFS"
+    unset OLDIFS
+
+    echo ${cryptname} > /.cryptname
+    echo ${cryptargs} > /.cryptargs
+
+    if resolved=$(resolve_device "${cryptdev}" ${rootdelay}); then
+
+        echo ${resolved} > /.cryptdev
+
+        if cryptsetup isLuks ${resolved} >/dev/null 2>&1; then
+            [ ${DEPRECATED_CRYPT} -eq 1 ] && warn_deprecated
+            dopassphrase=1
+            # If keyfile exists, try to use that
+            if [ -f ${ckeyfile} ]; then
+                if eval cryptsetup --key-file ${ckeyfile} open --type luks ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; then
+                    dopassphrase=0
+                else
+                    echo "Invalid keyfile. Reverting to passphrase."
                 fi
-                # Ask for a passphrase
-                if [ ${dopassphrase} -gt 0 ]; then
-                    echo ""
-                    echo "A password is required to access the ${cryptname} volume:"
+            fi
+            # Ask for a passphrase
+            if [ ${dopassphrase} -gt 0 ]; then
+                echo ""
+                echo "A password is required to access the ${cryptname} volume:"
 
-                    #loop until we get a real password
-                    while ! eval /sbin/cryptsetup luksOpen ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; do
-                     if [ -f /.done ]; then
-                         break
-                     fi
-
-                        sleep 2;
-                    done
-
+                #loop until we get a real password
+                while ! eval cryptsetup open --type luks ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; do
                     if [ -f /.done ]; then
-                        rm /.done
+                        break
                     fi
 
-                    if [ -f /.cryptdev ]; then
-                        rm /.cryptdev
-                    fi
+                    sleep 2;
+                done
 
-                    if [ -f /.cryptname ]; then
-                        rm /.cryptname
-                    fi
+                if [ -f /.done ]; then
+                    rm /.done
+                fi
 
-                    if [ -f /.cryptargs ]; then
-                        rm /.cryptargs
-                    fi
+                if [ -f /.cryptdev ]; then
+                    rm /.cryptdev
                 fi
-                if [ -e "/dev/mapper/${cryptname}" ]; then
-                    if [ ${DEPRECATED_CRYPT} -eq 1 ]; then
-                        export root="/dev/mapper/root"
-                    fi
-                else
-                    err "Password succeeded, but ${cryptname} creation failed, aborting..."
-                    exit 1
-                fi
-            elif [ -n "${crypto}" ]; then
-                [ ${DEPRECATED_CRYPT} -eq 1 ] && warn_deprecated
-                msg "Non-LUKS encrypted device found..."
-                if [ $# -ne 5 ]; then
-                    err "Verify parameter format: crypto=hash:cipher:keysize:offset:skip"
-                    err "Non-LUKS decryption not attempted..."
-                    return 1
-                fi
-                exe="/sbin/cryptsetup create ${cryptname} ${cryptdev} ${cryptargs}"
-                tmp=$(echo "${crypto}" | cut -d: -f1)
-                [ -n "${tmp}" ] && exe="${exe} --hash \"${tmp}\""
-                tmp=$(echo "${crypto}" | cut -d: -f2)
-                [ -n "${tmp}" ] && exe="${exe} --cipher \"${tmp}\""
-                tmp=$(echo "${crypto}" | cut -d: -f3)
-                [ -n "${tmp}" ] && exe="${exe} --key-size \"${tmp}\""
-                tmp=$(echo "${crypto}" | cut -d: -f4)
-                [ -n "${tmp}" ] && exe="${exe} --offset \"${tmp}\""
-                tmp=$(echo "${crypto}" | cut -d: -f5)
-                [ -n "${tmp}" ] && exe="${exe} --skip \"${tmp}\""
-                if [ -f ${ckeyfile} ]; then
-                    exe="${exe} --key-file ${ckeyfile}"
-                else
-                    exe="${exe} --verify-passphrase"
-                    echo ""
-                    echo "A password is required to access the ${cryptname} volume:"
-                fi
-                eval "${exe} ${CSQUIET}"
 
-                if [ $? -ne 0 ]; then
-                    err "Non-LUKS device decryption failed. verify format: "
-                    err "      crypto=hash:cipher:keysize:offset:skip"
-                    exit 1
+                if [ -f /.cryptname ]; then
+                    rm /.cryptname
                 fi
-                if [ -e "/dev/mapper/${cryptname}" ]; then
-                    if [ ${DEPRECATED_CRYPT} -eq 1 ]; then
-                        export root="/dev/mapper/root"
-                    fi
-                else
-                    err "Password succeeded, but ${cryptname} creation failed, aborting..."
-                    exit 1
+
+                if [ -f /.cryptargs ]; then
+                    rm /.cryptargs
+                fi
+            fi
+            if [ -e "/dev/mapper/${cryptname}" ]; then
+                if [ ${DEPRECATED_CRYPT} -eq 1 ]; then
+                    export root="/dev/mapper/root"
                 fi
             else
-                err "Failed to open encryption mapping: The device ${cryptdev} is not a LUKS volume and the crypto= paramater was not specified."
+                err "Password succeeded, but ${cryptname} creation failed, aborting..."
+                return 1
             fi
+        elif [ -n "${crypto}" ]; then
+            [ ${DEPRECATED_CRYPT} -eq 1 ] && warn_deprecated
+            msg "Non-LUKS encrypted device found..."
+            if echo "$crypto" | awk -F: '{ exit(NF == 5) }'; then
+                err "Verify parameter format: crypto=hash:cipher:keysize:offset:skip"
+                err "Non-LUKS decryption not attempted..."
+                return 1
+            fi
+            exe="cryptsetup open --type plain $resolved $cryptname $cryptargs"
+            IFS=: read c_hash c_cipher c_keysize c_offset c_skip <<EOF
+$crypto
+EOF
+            [ -n "$c_hash" ]    && exe="$exe --hash '$c_hash'"
+            [ -n "$c_cipher" ]  && exe="$exe --cipher '$c_cipher'"
+            [ -n "$c_keysize" ] && exe="$exe --key-size '$c_keysize'"
+            [ -n "$c_offset" ]  && exe="$exe --offset '$c_offset'"
+            [ -n "$c_skip" ]    && exe="$exe --skip '$c_skip'"
+            if [ -f "$ckeyfile" ]; then
+                exe="$exe --key-file $ckeyfile"
+            else
+                echo ""
+                echo "A password is required to access the ${cryptname} volume:"
+            fi
+            eval "$exe $CSQUIET"
+
+            if [ $? -ne 0 ]; then
+                err "Non-LUKS device decryption failed. verify format: "
+                err "      crypto=hash:cipher:keysize:offset:skip"
+                return 1
+            fi
+            if [ -e "/dev/mapper/${cryptname}" ]; then
+                if [ ${DEPRECATED_CRYPT} -eq 1 ]; then
+                    export root="/dev/mapper/root"
+                fi
+            else
+                err "Password succeeded, but ${cryptname} creation failed, aborting..."
+                return 1
+            fi
+        else
+            err "Failed to open encryption mapping: The device ${cryptdev} is not a LUKS volume and the crypto= paramater was not specified."
         fi
-        rm -f ${ckeyfile}
     fi
+    rm -f ${ckeyfile}
 }
 

--- a/initcpio/install/encryptssh
+++ b/initcpio/install/encryptssh
@@ -8,7 +8,8 @@ make_etc_passwd() {
 build() {
     local mod
 
-    add_module dm-crypt
+    add_module 'dm-crypt'
+    add_module 'dm-integrity'
     if [[ $CRYPTO_MODULES ]]; then
         for mod in $CRYPTO_MODULES; do
             add_module "$mod"
@@ -18,11 +19,12 @@ build() {
     fi
 
     add_binary "cryptsetup"
-    add_binary "dmsetup"
-    add_file "/usr/lib/udev/rules.d/10-dm.rules"
-    add_file "/usr/lib/udev/rules.d/13-dm-disk.rules"
-    add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
-    add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
+
+    map add_udev_rule \
+        '10-dm.rules' \
+        '13-dm-disk.rules' \
+        '95-dm-notify.rules' \
+        '/usr/lib/initcpio/udev/11-dm-initramfs.rules'
 
     add_binary "/usr/share/mkinitcpio-utils/utils/shells/cryptsetup_shell" "/bin/cryptsetup_shell"
 

--- a/utils/shells/cryptsetup_shell
+++ b/utils/shells/cryptsetup_shell
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ -c "/dev/mapper/control" ]; then
-    if eval /sbin/cryptsetup luksOpen \`cat /.cryptdev\` \`cat /.cryptname\` \`cat /.cryptargs\` ; then
+    if eval cryptsetup open --type luks \`cat /.cryptdev\` \`cat /.cryptname\` \`cat /.cryptargs\` ; then
         echo > /.done
         killall cryptsetup
     fi


### PR DESCRIPTION
By doing so, that include key features:

- resolve_device instead of poll_device to allow persistent block device naming.
- support discard, perf-no_read_workqueue and perf-no_write_workqueue