### PR TITLE
Add plymouth support

### DIFF
--- a/initcpio/hooks/encryptssh
+++ b/initcpio/hooks/encryptssh
@@ -87,17 +87,23 @@ run_hook ()
                 fi
                 # Ask for a passphrase
                 if [ ${dopassphrase} -gt 0 ]; then
-                    echo ""
-                    echo "A password is required to access the ${cryptname} volume:"
+                    if command -v plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null; then
+                        plymouth ask-for-password \
+                            --prompt="A password is required to access the ${cryptname} volume" \
+                            --command="/sbin/cryptsetup luksOpen ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}"
+                    else
+                        echo ""
+                        echo "A password is required to access the ${cryptname} volume:"
 
-                    #loop until we get a real password
-                    while ! eval /sbin/cryptsetup luksOpen ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; do
-                     if [ -f /.done ]; then
-                         break
-                     fi
+                        #loop until we get a real password
+                        while ! eval /sbin/cryptsetup luksOpen ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}; do
+                            if [ -f /.done ]; then
+                                break
+                            fi
 
-                        sleep 2;
-                    done
+                            sleep 2;
+                        done
+                    fi
 
                     if [ -f /.done ]; then
                         rm /.done

--- a/utils/shells/cryptsetup_shell
+++ b/utils/shells/cryptsetup_shell
@@ -3,6 +3,7 @@ if [ -c "/dev/mapper/control" ]; then
     if eval /sbin/cryptsetup luksOpen \`cat /.cryptdev\` \`cat /.cryptname\` \`cat /.cryptargs\` ; then
         echo > /.done
         killall cryptsetup
+        killall --quiet plymouth
     fi
 else
     echo "encryption bootup not succeeded. please wait!"


### PR DESCRIPTION
Add plymouth support.

This was proposed in #3 (and previously implemented in #4) when plymouth-encrypt was a separate hook.
Since the encrypt hook now integrates plymouth (see [gitlab commit 0fbb392a](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/0fbb392a0d16fd80347fa798e8fbcbf0205d2cf3)), it would be nice to also add support in encryptssh.

I adapted the encrypt plymouth code to this repo, also adding a `killall --quiet plymouth` to the custom shell (as in #4) to make sure remote decryption works properly.
I tested local and remote decryption both with/without plymouth hook and everything seems to work.