### PR TITLE
encryptssh: skip crypt setup if crypt device is already open

### DIFF
--- a/initcpio/hooks/encryptssh
+++ b/initcpio/hooks/encryptssh
@@ -47,6 +47,11 @@ run_hook ()
             cryptname="root"
         fi
 
+        if [ -b "/dev/mapper/${cryptname}" ]; then
+            echo "Device ${cryptname} already exists, not doing any crypt setup."
+            return 0
+        fi
+
         warn_deprecated() {
             echo "The syntax 'root=${root}' where '${root}' is an encrypted volume is deprecated"
             echo "Use 'cryptdevice=${root}:root root=/dev/mapper/root' instead."


### PR DESCRIPTION
Resolves #22.

If the crypt device to be open already exists, skip and carry on with the boot sequence.

This allows other hooks to set the crypt device up before encryptssh (e.g. clevis).