### PR TITLE
remove deprecated 11-dm-initramfs.rules

### DIFF
--- a/initcpio/install/encryptssh
+++ b/initcpio/install/encryptssh
@@ -23,7 +23,6 @@ build() {
     add_file "/usr/lib/udev/rules.d/10-dm.rules"
     add_file "/usr/lib/udev/rules.d/13-dm-disk.rules"
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
-    add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
 
     add_binary "/usr/share/mkinitcpio-utils/utils/shells/cryptsetup_shell" "/bin/cryptsetup_shell"
 


### PR DESCRIPTION
Resolves #24

Removing `11-dm-initramfs.rules` as its usage leads to an error during mkinitcpio and `db_persist` option is already handled by `10-dm.rules`.
https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/merge_requests/416